### PR TITLE
IPv6 support

### DIFF
--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ var (
 
 	fastclient = fasthttp.Client{
 		NoDefaultUserAgentHeader: true,
-		Dial:                     defaultDialer.Dial,
+		Dial:                     defaultDialer.DialDualStack,
 		MaxConnWaitTimeout:       3 * time.Second,
 	}
 )


### PR DESCRIPTION
Fix "ERROR Client timeout: couldn't find DNS entries for the given domain. Try using DialDualStack"

I was about the open an Issue, but the error message was very explicit when trying to access an IPv6 only URL, and fixing it was trivial:
```
$ curl -x http://fpgo:3129 http://ip4.saou.eu/
57.1.2.3
example.net (valid)
France
```
And:
```
$ curl -x http://fpgo:3129 http://ip6.saou.eu/
2001:41d0:a:b:c::1
example.net (invalid)
France
```